### PR TITLE
[0.11.x] Migrate NPC hero.skills to system.skills.value

### DIFF
--- a/data/npcs/bolverkt-djpdvergr-scout.json
+++ b/data/npcs/bolverkt-djpdvergr-scout.json
@@ -4188,8 +4188,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "dFKiwPs0hVo7uWei"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/bryn-ketilsdottir.json
+++ b/data/npcs/bryn-ketilsdottir.json
@@ -4306,8 +4306,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/brynja-steinsdottir-refugee-leader.json
+++ b/data/npcs/brynja-steinsdottir-refugee-leader.json
@@ -4436,8 +4436,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "RhaBwqKzijzbJcCQ"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/eirik-greyhand.json
+++ b/data/npcs/eirik-greyhand.json
@@ -4263,8 +4263,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "dFKiwPs0hVo7uWei"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/elder-thyra-steamoasis-leader.json
+++ b/data/npcs/elder-thyra-steamoasis-leader.json
@@ -4630,8 +4630,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/gragnir-the-druid.json
+++ b/data/npcs/gragnir-the-druid.json
@@ -4694,8 +4694,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/high-king-harald.json
+++ b/data/npcs/high-king-harald.json
@@ -4953,8 +4953,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "ZQVco8CZprfeqPp6"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/hild.json
+++ b/data/npcs/hild.json
@@ -4132,8 +4132,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "eQsxbl59pEjHEyB7"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/hildvar-bruneson-forgemaster.json
+++ b/data/npcs/hildvar-bruneson-forgemaster.json
@@ -5049,8 +5049,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/kaelen-the-seventh.json
+++ b/data/npcs/kaelen-the-seventh.json
@@ -5212,8 +5212,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/lew-tosferd.json
+++ b/data/npcs/lew-tosferd.json
@@ -4531,8 +4531,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "zW9eM46rG8tUhTaA"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/soldis-glodfari.json
+++ b/data/npcs/soldis-glodfari.json
@@ -4320,8 +4320,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "zW9eM46rG8tUhTaA"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/solveig-the-burner.json
+++ b/data/npcs/solveig-the-burner.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "_id": "8LIc1dYQDHfDYpDf",
   "name": "Solveig the Burner",
   "img": "modules/svellheim-entities/assets/icons/npc-images/solveig-the-burner.png",
@@ -3790,8 +3790,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "jHJnlHyRRNf9V5hm"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/solvi.json
+++ b/data/npcs/solvi.json
@@ -4410,8 +4410,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": null
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/thrinn-ashward-pale-maw-inquisitor.json
+++ b/data/npcs/thrinn-ashward-pale-maw-inquisitor.json
@@ -4737,8 +4737,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "74X1pEcNgz1OQC2x"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/thyra-blackhand.json
+++ b/data/npcs/thyra-blackhand.json
@@ -4511,8 +4511,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "IWcztYRBrAMdRQyf"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/vigmund-haldorsson-jarl-of-rindgate.json
+++ b/data/npcs/vigmund-haldorsson-jarl-of-rindgate.json
@@ -4197,8 +4197,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "IWcztYRBrAMdRQyf"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }

--- a/data/npcs/yrsa-frostbane-pale-maw-strike-leader.json
+++ b/data/npcs/yrsa-frostbane-pale-maw-strike-leader.json
@@ -4422,8 +4422,11 @@
       "victories": 0,
       "renown": 0,
       "wealth": 1,
-      "skills": [],
       "preferredKit": "ZQVco8CZprfeqPp6"
+    },
+    "skills": {
+      "value": [],
+      "modifiers": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

Migrates 18 hero-type NPC JSON files from the old skills data path to the new path introduced in draw-steel 0.11.x.

## Changes

For each of the 18 hero-type NPCs in `data/npcs/`:
- Removed `system.hero.skills` array
- Added `system.skills.value` array (same values)
- Added `system.skills.modifiers` empty object

5 pure NPC-type actors (no hero sub-object) were unaffected.

Closes #42
