### PR TITLE
[0.11.x] Update compatibility for draw-steel 0.11.x and Foundry 13.351

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,21 +4,26 @@
   "description": "Shared NPCs, monsters, items, and projects for the Svellheim campaign setting (Draw Steel system).",
   "url": "https://github.com/bruceamoser/Svellheim-Entities",
   "manifest": "https://github.com/bruceamoser/Svellheim-Entities/releases/latest/download/module.json",
-  "download": "https://github.com/bruceamoser/Svellheim-Entities/releases/download/v0.1.17/svellheim-entities-v0.1.17.zip",
-  "version": "0.1.17",
+  "download": "https://github.com/bruceamoser/Svellheim-Entities/releases/download/v0.1.18/svellheim-entities-v0.1.18.zip",
+  "version": "0.1.18",
   "authors": [
     {
       "name": "Bruce A. Moser"
     }
   ],
   "compatibility": {
-    "minimum": "11",
-    "verified": "13"
+    "minimum": "13",
+    "verified": "13.351"
   },
   "relationships": {
     "systems": [
       {
-        "id": "draw-steel"
+        "id": "draw-steel",
+        "type": "system",
+        "compatibility": {
+          "minimum": "0.9.0",
+          "verified": "0.11.1"
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary

Updates compatibility declarations for draw-steel 0.11.x support.

## Changes

- Updated Foundry minimum from `11` to `13`; verified from `13` to `13.351`
- Added draw-steel system compatibility: minimum `0.9.0`, verified `0.11.1`
- Bumped module version to `0.1.18`

Closes #43
